### PR TITLE
chore(ci): reduce test concurrency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,14 +230,46 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  examples:
+    name: Examples
+
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    needs:
+      - coverage
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          components: clippy,rustfmt
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+
+      - name: Install Rust tools
+        uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a  # v2.75.0
+        with:
+          tool: cargo-hack
+
+      - name: Run examples
+        env:
+          AMBER_API_KEY: ${{ secrets.AMBER_API_KEY }}
+        run: ./scripts/ci/run-examples
+
   test:
     name: Test Rust ${{ matrix.rust }} on  ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
 
     runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
-
+    needs:
+      - examples
     strategy:
       fail-fast: false
+      # To avoid hitting Amber's rate limit in parallel
+      max-parallel: 1
       matrix:
         os:
           - ubuntu-latest
@@ -270,33 +302,6 @@ jobs:
         shell: bash
         env:
           AMBER_API_KEY: ${{ secrets.AMBER_API_KEY }}
-        run: |
+        run: |-
           cargo hack --feature-powerset \
             nextest run --workspace
-
-  examples:
-    name: Examples
-
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-        with:
-          components: clippy,rustfmt
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-
-      - name: Install Rust tools
-        uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a  # v2.75.0
-        with:
-          tool: cargo-hack
-
-      - name: Run examples
-        env:
-          AMBER_API_KEY: ${{ secrets.AMBER_API_KEY }}
-        run: ./scripts/ci/run-examples


### PR DESCRIPTION
While we will likely hit Amber's rate limit anyway, running the tasks sequentially ensures that only one run is waiting, instead of having parallel jobs waiting.
